### PR TITLE
Saved Songs - rename screen and add search

### DIFF
--- a/src/navigation/CustomTabBar.tsx
+++ b/src/navigation/CustomTabBar.tsx
@@ -19,7 +19,7 @@ const TAB_META: Record<string, { icon: IoniconName; iconFocused: IoniconName; la
   Editor:  { icon: 'create-outline',         iconFocused: 'create',         label: 'Editor'  },
   Web:     { icon: 'globe-outline',           iconFocused: 'globe',          label: 'Web'     },
   Learn:   { icon: 'school-outline',          iconFocused: 'school',         label: 'Learn'   },
-  Lyrics:  { icon: 'musical-notes-outline',   iconFocused: 'musical-notes',  label: 'Lyrics'  },
+  Lyrics:  { icon: 'musical-notes-outline',   iconFocused: 'musical-notes',  label: 'Songs'   },
   Words:   { icon: 'book-outline',            iconFocused: 'book',           label: 'Words'   },
 };
 

--- a/src/screens/LyricsScreen.tsx
+++ b/src/screens/LyricsScreen.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   StyleSheet,
   TextInput,
+  Image,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useStore } from '../store/useStore';
@@ -17,6 +18,54 @@ import ScreenWrapper from '../components/ScreenWrapper';
 import { useIsWide } from '../hooks/useLayout';
 import ConfirmDialog from '../components/ConfirmDialog';
 import { useBackToQuit } from '../hooks/useBackToQuit';
+import { getFaviconUrl } from '../utils/getFaviconUrl';
+
+function HighlightedText({
+  text,
+  query,
+  style,
+  numberOfLines,
+}: {
+  text: string;
+  query: string;
+  style: any;
+  numberOfLines?: number;
+}) {
+  if (!query.trim()) {
+    return <Text style={style} numberOfLines={numberOfLines}>{text}</Text>;
+  }
+
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  const parts: { text: string; highlight: boolean }[] = [];
+  let lastIndex = 0;
+  let index = lowerText.indexOf(lowerQuery);
+
+  while (index !== -1) {
+    if (index > lastIndex) {
+      parts.push({ text: text.slice(lastIndex, index), highlight: false });
+    }
+    parts.push({ text: text.slice(index, index + query.length), highlight: true });
+    lastIndex = index + query.length;
+    index = lowerText.indexOf(lowerQuery, lastIndex);
+  }
+
+  if (lastIndex < text.length) {
+    parts.push({ text: text.slice(lastIndex), highlight: false });
+  }
+
+  return (
+    <Text style={style} numberOfLines={numberOfLines}>
+      {parts.map((part, i) =>
+        part.highlight ? (
+          <Text key={i} style={styles.highlight}>{part.text}</Text>
+        ) : (
+          <Text key={i}>{part.text}</Text>
+        )
+      )}
+    </Text>
+  );
+}
 
 export default function LyricsScreen() {
   const navigation = useNavigation<any>();
@@ -74,8 +123,23 @@ export default function LyricsScreen() {
       activeOpacity={0.7}
     >
       <View style={styles.cardLeft}>
-        <Text style={styles.songName} numberOfLines={1}>{item.songName}</Text>
-        <Text style={styles.artistName} numberOfLines={1}>{item.artistName || 'Unknown Artist'}</Text>
+        <View style={styles.songNameRow}>
+          <HighlightedText
+            text={item.songName}
+            query={searchQuery}
+            style={styles.songName}
+            numberOfLines={1}
+          />
+          {getFaviconUrl(item.sourceUrl ?? '') && (
+            <Image source={{ uri: getFaviconUrl(item.sourceUrl ?? '')! }} style={styles.sourceFavicon} />
+          )}
+        </View>
+        <HighlightedText
+          text={item.artistName || 'Unknown Artist'}
+          query={searchQuery}
+          style={styles.artistName}
+          numberOfLines={1}
+        />
         <View style={styles.meta}>
           <Text style={styles.metaText}>{getWordCount(item)} words</Text>
           <View style={styles.languages}>
@@ -94,7 +158,18 @@ export default function LyricsScreen() {
   return (
     <ScreenWrapper>
       <View style={styles.titleRow}>
-        <Text style={styles.title}>Saved Songs</Text>
+        {showSearch ? (
+          <TextInput
+            style={styles.searchInput}
+            placeholder="Search by title or artist..."
+            placeholderTextColor={Colors.textMuted}
+            value={searchQuery}
+            onChangeText={setSearchQuery}
+            autoFocus
+          />
+        ) : (
+          <Text style={styles.title}>Saved Songs</Text>
+        )}
         <TouchableOpacity onPress={toggleSearch} style={styles.searchButton}>
           <Ionicons
             name={showSearch ? 'close' : 'search'}
@@ -103,16 +178,6 @@ export default function LyricsScreen() {
           />
         </TouchableOpacity>
       </View>
-      {showSearch && (
-        <TextInput
-          style={styles.searchInput}
-          placeholder="Search by title or artist..."
-          placeholderTextColor={Colors.textMuted}
-          value={searchQuery}
-          onChangeText={setSearchQuery}
-          autoFocus
-        />
-      )}
       {filteredSongs.length === 0 ? (
         <View style={styles.empty}>
           {songs.length === 0 ? (
@@ -174,6 +239,7 @@ const styles = StyleSheet.create({
     padding: 4,
   },
   searchInput: {
+    flex: 1,
     backgroundColor: Colors.surface,
     borderRadius: 12,
     paddingHorizontal: 16,
@@ -182,7 +248,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     borderWidth: 1,
     borderColor: Colors.border,
-    marginBottom: 16,
+    marginRight: 8,
+  },
+  highlight: {
+    backgroundColor: '#F5C542',
+    color: '#1A1A1A',
   },
   list: {
     paddingBottom: 40,
@@ -207,10 +277,21 @@ const styles = StyleSheet.create({
   cardLeft: {
     flex: 1,
   },
+  songNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
   songName: {
+    flexShrink: 1,
     fontSize: 17,
     fontWeight: '600',
     color: Colors.text,
+  },
+  sourceFavicon: {
+    width: 14,
+    height: 14,
+    borderRadius: 2,
   },
   artistName: {
     fontSize: 14,

--- a/src/screens/LyricsScreen.tsx
+++ b/src/screens/LyricsScreen.tsx
@@ -5,6 +5,7 @@ import {
   FlatList,
   TouchableOpacity,
   StyleSheet,
+  TextInput,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useStore } from '../store/useStore';
@@ -24,6 +25,16 @@ export default function LyricsScreen() {
   useBackToQuit();
   const numColumns = isWide ? 2 : 1;
   const [songToDelete, setSongToDelete] = useState<Song | null>(null);
+  const [showSearch, setShowSearch] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredSongs = searchQuery.trim()
+    ? songs.filter(
+        (s) =>
+          s.songName.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          s.artistName.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+    : songs;
 
   const handlePressSong = (song: Song) => {
     setCurrentSongId(song.id);
@@ -48,6 +59,11 @@ export default function LyricsScreen() {
   const getWordCount = (song: Song) => {
     const words = song.originalLyrics.split(/\s+/).filter(Boolean);
     return words.length;
+  };
+
+  const toggleSearch = () => {
+    if (showSearch) setSearchQuery('');
+    setShowSearch((v) => !v);
   };
 
   const renderSong = ({ item }: { item: Song }) => (
@@ -78,18 +94,44 @@ export default function LyricsScreen() {
   return (
     <ScreenWrapper>
       <View style={styles.titleRow}>
-        <Text style={styles.title}>Saved Lyrics</Text>
+        <Text style={styles.title}>Saved Songs</Text>
+        <TouchableOpacity onPress={toggleSearch} style={styles.searchButton}>
+          <Ionicons
+            name={showSearch ? 'close' : 'search'}
+            size={22}
+            color={Colors.textMuted}
+          />
+        </TouchableOpacity>
       </View>
-      {songs.length === 0 ? (
+      {showSearch && (
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Search by title or artist..."
+          placeholderTextColor={Colors.textMuted}
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          autoFocus
+        />
+      )}
+      {filteredSongs.length === 0 ? (
         <View style={styles.empty}>
-          <Ionicons name="library-outline" size={64} color={Colors.textMuted} />
-          <Text style={styles.emptyText}>No saved lyrics yet.{'\n'}Go to Editor to add some!</Text>
+          {songs.length === 0 ? (
+            <>
+              <Ionicons name="library-outline" size={64} color={Colors.textMuted} />
+              <Text style={styles.emptyText}>No saved songs yet.{'\n'}Go to Editor to add some!</Text>
+            </>
+          ) : (
+            <>
+              <Ionicons name="search-outline" size={64} color={Colors.textMuted} />
+              <Text style={styles.emptyText}>No songs match your search.</Text>
+            </>
+          )}
         </View>
       ) : (
         <FlatList
           key={numColumns}
           numColumns={numColumns}
-          data={songs}
+          data={filteredSongs}
           keyExtractor={(item) => item.id}
           renderItem={renderSong}
           columnWrapperStyle={isWide ? styles.row : undefined}
@@ -127,6 +169,20 @@ const styles = StyleSheet.create({
     fontSize: 26,
     fontWeight: '700',
     color: Colors.text,
+  },
+  searchButton: {
+    padding: 4,
+  },
+  searchInput: {
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    color: Colors.text,
+    fontSize: 16,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    marginBottom: 16,
   },
   list: {
     paddingBottom: 40,


### PR DESCRIPTION
Closes #33

- Rename "Saved Lyrics" screen title and bottom nav label to "Saved Songs" / "Songs"
- Add a magnifier icon in the top-right of the title row; tapping toggles a search TextInput
- Search filters by song title or artist name (case-insensitive)
- Shows a "No songs match your search" empty state when no results are found

Generated with [Claude Code](https://claude.ai/code)