### PR TITLE
fix: close word panel when switching songs in Learn

### DIFF
--- a/src/screens/LearnScreen.tsx
+++ b/src/screens/LearnScreen.tsx
@@ -64,6 +64,12 @@ export default function LearnScreen() {
     }
   }, [blurTranslations, currentSongId]);
 
+  // Close word panel when switching songs
+  useEffect(() => {
+    setSelectedWord(null);
+    setSelectedLine(null);
+  }, [currentSongId]);
+
   // Auto-hide toast after 2 seconds
   useEffect(() => {
     if (showToast) {


### PR DESCRIPTION
Closes #78

When switching to another song in the Learn screen, the word panel now closes automatically.

Added a `useEffect` in `LearnScreen.tsx` that resets `selectedWord` and `selectedLine` to `null` when `currentSongId` changes.

Generated with [Claude Code](https://claude.ai/code)