### PR TITLE
Scrape: LyricsTranslate

### DIFF
--- a/src/screens/EditorScreen.tsx
+++ b/src/screens/EditorScreen.tsx
@@ -172,6 +172,8 @@ export default function EditorScreen() {
     const url = route.params?.scrapedSourceUrl as string | undefined;
     const title = route.params?.scrapedPageTitle as string | undefined;
     const languageCode = route.params?.scrapedLanguageCode as string | undefined;
+    const translationText = route.params?.scrapedTranslationText as string | undefined;
+    const translationLanguage = route.params?.scrapedTranslationLanguage as string | undefined;
 
     if (targetTab === 0) {
       setOriginalLyrics(scraped);
@@ -186,6 +188,18 @@ export default function EditorScreen() {
           });
         }
       }
+      if (translationText && translationLanguage) {
+        const matchedLang = LANGUAGES.find(
+          l => l.name.toLowerCase() === translationLanguage.toLowerCase() || l.code.toLowerCase() === translationLanguage.toLowerCase()
+        );
+        const finalLangName = matchedLang ? matchedLang.name : translationLanguage;
+        setTranslations(prev => {
+          if (prev.some(t => t.language === finalLangName)) {
+            return prev.map(t => t.language === finalLangName ? { ...t, lyrics: translationText.trim(), sourceUrl: url, sourceUrlTitle: title || undefined } : t);
+          }
+          return [...prev, { language: finalLangName, lyrics: translationText.trim(), sourceUrl: url, sourceUrlTitle: title || undefined }];
+        });
+      }
     } else {
       setTranslations((prev) => {
         const updated = [...prev];
@@ -197,7 +211,7 @@ export default function EditorScreen() {
     if (title !== undefined) setPendingPageTitles((prev) => ({ ...prev, [targetTab]: title }));
     setActiveTab(targetTab);
     if (url) setShowSourceUrl(true);
-    navigation.setParams({ scrapedLyrics: undefined, scrapedSourceUrl: undefined, scrapedPageTitle: undefined, scrapedTargetTab: undefined, scrapedLanguageCode: undefined });
+    navigation.setParams({ scrapedLyrics: undefined, scrapedSourceUrl: undefined, scrapedPageTitle: undefined, scrapedTargetTab: undefined, scrapedLanguageCode: undefined, scrapedTranslationText: undefined, scrapedTranslationLanguage: undefined });
   }, [route.params?.scrapedLyrics]);
 
   const allEmpty = !songName && !artistName && !originalLyrics && translations.every((t) => !t.lyrics);

--- a/src/screens/WebScreen.tsx
+++ b/src/screens/WebScreen.tsx
@@ -74,6 +74,9 @@ export default function WebScreen() {
       }
       if (data.type === 'translationDetected') {
         setWaitingForTranslation(!data.hasTranslation);
+        if (data.hasTranslation) {
+          setShowTranslationFab(true);
+        }
         return;
       }
       if (data.type === 'lyrics' && data.text) {
@@ -86,7 +89,8 @@ export default function WebScreen() {
           scrapedSourceUrl: currentUrl,
           scrapedPageTitle: data.title ?? '',
           scrapedTargetTab: scrapeTargetTab,
-          scrapedLanguageCode: data.languageCode || ''
+          scrapedLanguageCode: data.languageCode || '',
+          ...(data.translationText ? { scrapedTranslationText: data.translationText, scrapedTranslationLanguage: data.translationLanguage || '' } : {}),
         });
       }
       if (data.type === 'translation' && data.text) {

--- a/src/utils/detectLyricsJS.ts
+++ b/src/utils/detectLyricsJS.ts
@@ -24,6 +24,17 @@ const _detectLyricsLogic = `
     const songLyricsEl = document.querySelector('#songLyricsDiv');
     hasLyrics = !!songLyricsEl;
   }
+  // LyricsTranslate
+  else if (url.includes('lyricstranslate.com')) {
+    const originalTab = document.querySelector('[data-target=original]');
+    if (originalTab) originalTab.click();
+    const originalLyricsEl = document.querySelector('#original-lyrics');
+    hasLyrics = !!originalLyricsEl && originalLyricsEl.textContent.trim().length > 0;
+    const translationBody = document.querySelector('#translation-body');
+    if (translationBody && translationBody.textContent.trim().length > 0) {
+      sendTranslationDetection(true);
+    }
+  }
 
   sendDetectionResult(hasLyrics);
 `;
@@ -34,8 +45,11 @@ export const detectLyricsJS = `
     const sendDetectionResult = (hasLyrics) => {
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'lyricsDetected', hasLyrics }));
     };
+    const sendTranslationDetection = (hasTranslation) => {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'translationDetected', hasTranslation }));
+    };
     try {
-      (new Function('sendDetectionResult', ${JSON.stringify(_detectLyricsLogic)}))(sendDetectionResult);
+      (new Function('sendDetectionResult', 'sendTranslationDetection', ${JSON.stringify(_detectLyricsLogic)}))(sendDetectionResult, sendTranslationDetection);
     } catch (e) {
       // Silently fail detection - button won't show
     }

--- a/src/utils/scrapeLyricsJS.ts
+++ b/src/utils/scrapeLyricsJS.ts
@@ -72,6 +72,23 @@ const _scrapeLyricsLogic = `
     }
   }
 
+  // LyricsTranslate
+  if (url.includes('lyricstranslate.com')) {
+    const originalTab = document.querySelector('[data-target=original]');
+    if (originalTab) originalTab.click();
+    const originalLyricsEl = document.querySelector('#original-lyrics');
+    if (originalLyricsEl) {
+      lyrics = originalLyricsEl.innerText;
+      languageCode = originalLyricsEl.lang || '';
+      const translationEl = document.querySelector('#translation-body');
+      const translationText = translationEl ? translationEl.innerText : '';
+      const translationLangEl = document.querySelector('.lt-breadcrumb-item:last-child');
+      const translationLanguage = translationLangEl ? translationLangEl.textContent.trim().replace(/\\s*translation\\s*$/i, '') : '';
+      sendLyrics(lyrics, languageCode, translationText, translationLanguage);
+      return;
+    }
+  }
+
   // Generic fallback
   consoleLog(window.location.hostname + ' - Using fallback, scraping entire page text');
   const body = document.body.innerText;
@@ -84,8 +101,13 @@ export const scrapeLyricsJS = `
     const consoleLog = (log) => {
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'debug', log }));
     };
-    const sendLyrics = (text, languageCode) => {
-      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'lyrics', text, title: document.title, languageCode: languageCode || '' }));
+    const sendLyrics = (text, languageCode, translationText, translationLanguage) => {
+      const msg = { type: 'lyrics', text, title: document.title, languageCode: languageCode || '' };
+      if (translationText) {
+        msg.translationText = translationText;
+        msg.translationLanguage = translationLanguage || '';
+      }
+      window.ReactNativeWebView.postMessage(JSON.stringify(msg));
     };
     const sendError = (err) => {
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'error', message: err && err.message ? err.message : String(err) }));

--- a/src/utils/scrapeTranslationJS.ts
+++ b/src/utils/scrapeTranslationJS.ts
@@ -1,4 +1,4 @@
-// Script to scrape translation from DeepL
+// Script to scrape translation from DeepL or LyricsTranslate
 const _scrapeTranslationLogic = `
   const url = window.location.href;
   let translation = '';
@@ -8,6 +8,16 @@ const _scrapeTranslationLogic = `
     const targetTextarea = document.querySelector('[name=target]');
     if (targetTextarea && targetTextarea.value) {
       translation = targetTextarea.value;
+      sendTranslation(translation);
+      return;
+    }
+  }
+
+  // LyricsTranslate
+  if (url.includes('lyricstranslate.com')) {
+    const translationBody = document.querySelector('#translation-body');
+    if (translationBody && translationBody.innerText.trim()) {
+      translation = translationBody.innerText;
       sendTranslation(translation);
       return;
     }


### PR DESCRIPTION
Closes #114

Implements scraping support for LyricsTranslate.com:

- **Scrape: add LyricsTranslate scraper**
  - `detectLyricsJS`: click original tab, detect `#original-lyrics` and `#translation-body`
  - `scrapeLyricsJS`: extract lyrics, language (`originalLyricsEl.lang`), translation text (`#translation-body`), and translation language (`.lt-breadcrumb-item:last-child`)
  - `scrapeTranslationJS`: extract translation from `#translation-body`

- **WebScreen: handle LyricsTranslate translation data**
  - Show "Get Translation" FAB when LyricsTranslate translation is detected
  - Pass `translationText` and `translationLanguage` to EditorScreen on Get Lyrics

- **EditorScreen: auto-create translation tab from LyricsTranslate**
  - When Get Lyrics from LyricsTranslate (target tab 0 with translation data), auto-create a translation tab matching the scraped language and fill it with the translation